### PR TITLE
Disable default atomics on const_default

### DIFF
--- a/crates/rlsf/Cargo.toml
+++ b/crates/rlsf/Cargo.toml
@@ -18,7 +18,7 @@ unstable = []
 [dependencies]
 svgbobdoc = { version = "0.2.2" }
 cfg-if = "1.0.0"
-const_default1 = { version = "1", package = "const-default" }
+const_default1 = { version = "1", package = "const-default", default-features = false }
 
 [target."cfg(unix)".dependencies]
 libc = "0.2.56"

--- a/crates/rlsf/src/lib.rs
+++ b/crates/rlsf/src/lib.rs
@@ -26,6 +26,7 @@ macro_rules! if_supported_target {
     ) => {
         #[cfg(any(
             all(target_arch = "wasm32", not(target_feature = "atomics")),
+            not(target_feature = "atomics"),
             unix,
             doc,
         ))]

--- a/crates/rlsf/src/lib.rs
+++ b/crates/rlsf/src/lib.rs
@@ -26,7 +26,6 @@ macro_rules! if_supported_target {
     ) => {
         #[cfg(any(
             all(target_arch = "wasm32", not(target_feature = "atomics")),
-            not(target_feature = "atomics"),
             unix,
             doc,
         ))]


### PR DESCRIPTION
This implies `enable-atomics` will be disabled so that targets like `riscv32imc-unknown-none-elf` can build