### PR TITLE
fix: infinite loop in iter_blocks

### DIFF
--- a/crates/rlsf/src/tlsf.rs
+++ b/crates/rlsf/src/tlsf.rs
@@ -1541,11 +1541,15 @@ impl<'pool, FLBitmap: BinInteger, SLBitmap: BinInteger, const FLLEN: usize, cons
                 let block_hdr = &*(start as *const BlockHdr);
                 let block_size = block_hdr.size & SIZE_SIZE_MASK;
 
-                // Advance the cursor
-                len -= block_size;
-                start = start.wrapping_add(block_size);
+                if block_size != 0 {
+                    // Advance the cursor
+                    len -= block_size;
+                    start = start.wrapping_add(block_size);
 
-                Some(BlockInfo { block_hdr })
+                    Some(BlockInfo { block_hdr })
+                } else {
+                    None
+                }
             }
         })
         .filter(|block_info| {


### PR DESCRIPTION
When block_size is equal to zero, iter_blocks will loop infinitely.
```
Block: BlockInfo { ptr: 0x202031e0..0x202131d0, size: 65520, is_occupied: false }
Block: BlockInfo { ptr: 0x202131e0..0x202231d0, size: 65520, is_occupied: false }
Block: BlockInfo { ptr: 0x202231e0..0x202331d0, size: 65520, is_occupied: false }
Block: BlockInfo { ptr: 0x202331e0..0x202431d0, size: 65520, is_occupied: false }
Block: BlockInfo { ptr: 0x202431e0..0x202531d0, size: 65520, is_occupied: false }
Block: BlockInfo { ptr: 0x202531e0..0x20253230, size: 80, is_occupied: true }
Block: BlockInfo { ptr: 0x20253230..0x20253260, size: 48, is_occupied: true }
Block: BlockInfo { ptr: 0x20253260..0x20253270, size: 16, is_occupied: true }
Block: BlockInfo { ptr: 0x20253270..0x20253680, size: 1040, is_occupied: true }
Block: BlockInfo { ptr: 0x20253680..0x20253690, size: 16, is_occupied: true }
Block: BlockInfo { ptr: 0x20253690..0x202536a0, size: 16, is_occupied: true }
Block: BlockInfo { ptr: 0x202536a0..0x20253800, size: 352, is_occupied: true }
Block: BlockInfo { ptr: 0x20253800..0x20253810, size: 16, is_occupied: true }
Block: BlockInfo { ptr: 0x20253810..0x20253850, size: 64, is_occupied: true }
Block: BlockInfo { ptr: 0x20253850..0x20253860, size: 16, is_occupied: false }
Block: BlockInfo { ptr: 0x20253860..0x202538a0, size: 64, is_occupied: true }
Block: BlockInfo { ptr: 0x202538a0..0x202538c0, size: 32, is_occupied: false }
Block: BlockInfo { ptr: 0x202538c0..0x20253b70, size: 688, is_occupied: true }
Block: BlockInfo { ptr: 0x20253b70..0x20253b90, size: 32, is_occupied: true }
Block: BlockInfo { ptr: 0x20253b90..0x20253ba0, size: 16, is_occupied: true }
Block: BlockInfo { ptr: 0x20253ba0..0x20253bc0, size: 32, is_occupied: true }
Block: BlockInfo { ptr: 0x20253bc0..0x20253e50, size: 656, is_occupied: true }
Block: BlockInfo { ptr: 0x20253e50..0x20253f20, size: 208, is_occupied: true }
Block: BlockInfo { ptr: 0x20253f20..0x202542f0, size: 976, is_occupied: true }
Block: BlockInfo { ptr: 0x202542f0..0x20254600, size: 784, is_occupied: true }
Block: BlockInfo { ptr: 0x20254600..0x202546e0, size: 224, is_occupied: true }
Block: BlockInfo { ptr: 0x202546e0..0x202547d0, size: 240, is_occupied: true }
Block: BlockInfo { ptr: 0x202547d0..0x20254810, size: 64, is_occupied: true }
Block: BlockInfo { ptr: 0x20254810..0x20254940, size: 304, is_occupied: true }
Block: BlockInfo { ptr: 0x20254940..0x20254a20, size: 224, is_occupied: true }
Block: BlockInfo { ptr: 0x20254a20..0x20254a90, size: 112, is_occupied: true }
Block: BlockInfo { ptr: 0x20254a90..0x20254f20, size: 1168, is_occupied: false }
Block: BlockInfo { ptr: 0x20254f20..0x20255430, size: 1296, is_occupied: true }
Block: BlockInfo { ptr: 0x20255430..0x202621c0, size: 52624, is_occupied: false }
Block: BlockInfo { ptr: 0x202621d0..0x202621d0, size: 0, is_occupied: false }
Block: BlockInfo { ptr: 0x202621d0..0x202621d0, size: 0, is_occupied: false }
Block: BlockInfo { ptr: 0x202621d0..0x202621d0, size: 0, is_occupied: false }
Block: BlockInfo { ptr: 0x202621d0..0x202621d0, size: 0, is_occupied: false }
Block: BlockInfo { ptr: 0x202621d0..0x202621d0, size: 0, is_occupied: false }
Block: BlockInfo { ptr: 0x202621d0..0x202621d0, size: 0, is_occupied: false }
Block: BlockInfo { ptr: 0x202621d0..0x202621d0, size: 0, is_occupied: false }
Block: BlockInfo { ptr: 0x202621d0..0x202621d0, size: 0, is_occupied: false }
...
```