### PR TITLE
Indicate that free blocks and allocations may not be initialized

### DIFF
--- a/crates/rlsf/src/global/unix.rs
+++ b/crates/rlsf/src/global/unix.rs
@@ -1,6 +1,7 @@
 use const_default1::ConstDefault;
 use core::{
     marker::PhantomData,
+    mem::MaybeUninit,
     ptr::{addr_of_mut, null_mut, NonNull},
 };
 
@@ -73,7 +74,7 @@ fn ensure_page_size_m1() -> usize {
 
 unsafe impl<Options: GlobalTlsfOptions> crate::flex::FlexSource for Source<Options> {
     #[inline]
-    unsafe fn alloc(&mut self, min_size: usize) -> Option<NonNull<[u8]>> {
+    unsafe fn alloc(&mut self, min_size: usize) -> Option<NonNull<[MaybeUninit<u8>]>> {
         let page_size_m1 = ensure_page_size_m1();
         let num_bytes = min_size.checked_add(page_size_m1)? & !page_size_m1;
 
@@ -91,7 +92,7 @@ unsafe impl<Options: GlobalTlsfOptions> crate::flex::FlexSource for Source<Optio
         }
 
         NonNull::new(core::ptr::slice_from_raw_parts_mut(
-            ptr as *mut u8,
+            ptr as *mut MaybeUninit<u8>,
             num_bytes,
         ))
     }
@@ -101,7 +102,7 @@ unsafe impl<Options: GlobalTlsfOptions> crate::flex::FlexSource for Source<Optio
     #[cfg(target_os = "linux")]
     unsafe fn realloc_inplace_grow(
         &mut self,
-        ptr: NonNull<[u8]>,
+        ptr: NonNull<[MaybeUninit<u8>]>,
         min_new_len: usize,
     ) -> Option<usize> {
         use crate::utils::nonnull_slice_len;

--- a/crates/rlsf/src/tlsf/tests.rs
+++ b/crates/rlsf/src/tlsf/tests.rs
@@ -145,7 +145,7 @@ macro_rules! gen_test {
 
                 let pool0_len = unsafe {
                     tlsf.insert_free_block_ptr(nonnull_slice_from_raw_parts(
-                        NonNull::new(cursor).unwrap(), remaining_len / 2))
+                        NonNull::new(cursor as *mut MaybeUninit<u8>).unwrap(), remaining_len / 2))
                 }.unwrap().get();
                 cursor = cursor.wrapping_add(pool0_len);
                 remaining_len -= pool0_len;
@@ -157,7 +157,7 @@ macro_rules! gen_test {
 
                 let _pool1_len = unsafe {
                     tlsf.append_free_block_ptr(nonnull_slice_from_raw_parts(
-                        NonNull::new(cursor).unwrap(), remaining_len))
+                        NonNull::new(cursor as *mut MaybeUninit<u8>).unwrap(), remaining_len))
                 };
 
                 log::trace!("tlsf = {:?}", tlsf);
@@ -225,7 +225,7 @@ macro_rules! gen_test {
                     pool_limit = pool.0.len() - pool_start;
 
                     let initial_pool = NonNull::new(std::ptr::slice_from_raw_parts_mut(
-                        pool_ptr,
+                        pool_ptr as *mut MaybeUninit<u8>,
                         pool_size
                     )).unwrap();
                     log::trace!("initial_pool = {:p}: [u8; {}]", pool_ptr, pool_size);
@@ -336,7 +336,7 @@ macro_rules! gen_test {
                                 u16::from_le_bytes([it.next()?, it.next()?]) as usize % (available + 1);
 
                             let appended = nonnull_slice_from_raw_parts(
-                                NonNull::new(pool_ptr.wrapping_add(old_pool_len)).unwrap(),
+                                NonNull::new(pool_ptr.wrapping_add(old_pool_len) as *mut MaybeUninit<u8>).unwrap(),
                                 num_appended_bytes,
                             );
 


### PR DESCRIPTION
Related to https://github.com/rust-embedded/embedded-alloc/issues/108

We are looking to avoid unsoundness while adding free blocks, so we want to avoid creating either &mut [u8] or &[u8].

Additionally, I believe this is the allocation behavior, hence the matching `FlexSource` trait change. This might be overkill since GlobalAlloc::alloc uses *mut u8 to represent maybe initialized u8.

Implementation | Initialization Behavior | Why
-- | -- | --
GlobalAllocAsFlexSource | ❌ Uninitialized | Calls GlobalAlloc::alloc which returns uninitialized memory per Rust docs
Unix mmap | ✅ Zero-initialized | POSIX guarantees MAP_ANONYMOUS pages are zeroed
WASM32 memory.grow | ✅ Zero-initialized | WebAssembly spec guarantees new pages are zeroed
Test CgFlexSource | ✅ Zero-initialized | Returns slice from Vec<u8> which is zeroed

