### PR TITLE
Replace dodgy pointer operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,19 @@ jobs:
         with:
           command: test
           args: --target wasm32-wasi -p rlsf nonexistent
+
+  test-miri:
+    name: Miri
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install nightly toolchain
+        run: |
+          echo nightly > rust-toolchain
+          rustup component add miri rust-src
+
+      - name: cargo miri test (partial)
+        # Miri is too slow to run all tests
+        run: cargo miri test -p rlsf --lib -- _u8_u8_8_8 global

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `GlobalTlsf` now implements `Default`.
 
+### Fixed
+
+- Fixed illegal pointer operations. `{Flex,}Tlsf` no longer trigger errors when running in MIRI.
+
 ## [0.2.1] - 2023-02-17
 
 ### Fixed

--- a/crates/rlsf/src/flex/tests.rs
+++ b/crates/rlsf/src/flex/tests.rs
@@ -86,9 +86,9 @@ unsafe impl<T: FlexSource> FlexSource for TrackingFlexSource<T> {
     unsafe fn dealloc(&mut self, ptr: NonNull<[u8]>) {
         // TODO: check that `ptr` represents an exact allocation, not just
         //       a part of it
+        self.sa.remove_pool(ptr.as_ptr());
         self.inner.dealloc(ptr);
         log::trace!("FlexSource::dealloc({:?})", ptr);
-        self.sa.remove_pool(ptr.as_ptr());
     }
 
     #[inline]

--- a/crates/rlsf/src/flex/tests.rs
+++ b/crates/rlsf/src/flex/tests.rs
@@ -140,7 +140,21 @@ unsafe impl FlexSource for CgFlexSource {
             .filter(|&x| x <= self.pool.len())?;
 
         self.allocated = new_allocated;
-        Some(NonNull::from(&mut self.pool[allocated..new_allocated]))
+
+        // Slice the allocated of `self.pool`.
+        //
+        // - Do not do `&mut self.pool[..]` because mutably borrowing the whole
+        //   `*self.pool` would invalidate the borrows made by previous
+        //   allocations.
+        //
+        // - Do not create a mutable reference even to the sliced out part
+        //   because the resulting pointer could not be expanded by
+        //   `realloc_inplace_grow`.
+        let pool_ptr = self.pool.as_mut_ptr();
+        Some(crate::utils::nonnull_slice_from_raw_parts(
+            NonNull::new(pool_ptr.add(allocated)).unwrap(),
+            new_allocated - allocated,
+        ))
     }
 
     unsafe fn realloc_inplace_grow(

--- a/crates/rlsf/src/lib.rs
+++ b/crates/rlsf/src/lib.rs
@@ -6,10 +6,12 @@
 #[doc = include_str!("../CHANGELOG.md")]
 pub mod _changelog_ {}
 
+#[macro_use]
+mod utils;
+
 mod flex;
 pub mod int;
 mod tlsf;
-mod utils;
 pub use self::{
     flex::*,
     tlsf::{Tlsf, GRANULARITY},

--- a/crates/rlsf/src/tlsf.rs
+++ b/crates/rlsf/src/tlsf.rs
@@ -9,7 +9,7 @@ use core::{
     marker::PhantomData,
     mem::{self, MaybeUninit},
     num::NonZeroUsize,
-    ptr::{addr_of, NonNull},
+    ptr::{addr_of, addr_of_mut, NonNull},
 };
 
 use crate::{
@@ -136,18 +136,19 @@ impl BlockHdr {
     ///
     /// # Safety
     ///
-    /// `self` must have a next block (it must not be the sentinel block in a
+    /// `this.size` must be safe to read.
+    ///
+    /// `this` must have a next block (it must not be the sentinel block in a
     /// pool).
     #[inline]
-    unsafe fn next_phys_block(&self) -> NonNull<BlockHdr> {
-        debug_assert!(
-            (self.size & SIZE_SENTINEL) == 0,
-            "`self` must not be a sentinel"
-        );
+    unsafe fn next_phys_block(this: *const Self) -> NonNull<BlockHdr> {
+        let size = (*this).size;
+
+        debug_assert!((size & SIZE_SENTINEL) == 0, "`self` must not be a sentinel");
 
         // Safety: Since `self.size & SIZE_SENTINEL` is not lying, the
         //         next block should exist at a non-null location.
-        NonNull::new_unchecked((self as *const _ as *mut u8).add(self.size & SIZE_SIZE_MASK)).cast()
+        NonNull::new_unchecked((this as *mut u8).add(size & SIZE_SIZE_MASK)).cast()
     }
 }
 
@@ -520,10 +521,7 @@ impl<'pool, FLBitmap: BinInteger, SLBitmap: BinInteger, const FLLEN: usize, cons
             };
 
             // Cap the end with a sentinel block (a permanently-used block)
-            let mut sentinel_block = block
-                .as_ref()
-                .common
-                .next_phys_block()
+            let mut sentinel_block = BlockHdr::next_phys_block(addr_of_mut!(block.as_mut().common))
                 .cast::<UsedBlockHdr>();
 
             sentinel_block.as_mut().common = BlockHdr {
@@ -791,12 +789,13 @@ impl<'pool, FLBitmap: BinInteger, SLBitmap: BinInteger, const FLLEN: usize, cons
 
             // Get a free block: `block`
             let first_free = self.first_free.get_unchecked_mut(fl).get_unchecked_mut(sl);
-            let block = first_free.unwrap_or_else(|| {
+            let mut block = first_free.unwrap_or_else(|| {
                 debug_assert!(false, "bitmap outdated");
                 // Safety: It's unreachable
                 unreachable_unchecked()
             });
-            let mut next_phys_block = block.as_ref().common.next_phys_block();
+            let mut next_phys_block =
+                BlockHdr::next_phys_block(addr_of_mut!(block.as_mut().common));
             let size_and_flags = block.as_ref().common.size;
             let size = size_and_flags /* size_and_flags & SIZE_SIZE_MASK */;
             debug_assert_eq!(size, size_and_flags & SIZE_SIZE_MASK);
@@ -1041,7 +1040,7 @@ impl<'pool, FLBitmap: BinInteger, SLBitmap: BinInteger, const FLLEN: usize, cons
         // Merge the created hole with the next block if the next block is a
         // free block
         // Safety: `block.common` should be fully up-to-date and valid
-        let next_phys_block = block.as_ref().next_phys_block();
+        let next_phys_block = BlockHdr::next_phys_block(block.as_ptr());
         let next_phys_block_size_and_flags = next_phys_block.as_ref().size;
         if (next_phys_block_size_and_flags & SIZE_USED) == 0 {
             let next_phys_block_size = next_phys_block_size_and_flags;
@@ -1055,7 +1054,7 @@ impl<'pool, FLBitmap: BinInteger, SLBitmap: BinInteger, const FLLEN: usize, cons
 
             // Safety: `next_phys_block` is a free block and therefore is not a
             // sentinel block
-            new_next_phys_block = next_phys_block.as_ref().next_phys_block();
+            new_next_phys_block = BlockHdr::next_phys_block(next_phys_block.as_ptr());
 
             // Unlink `next_phys_block`.
             self.unlink_free_block(next_phys_block.cast(), next_phys_block_size);
@@ -1092,11 +1091,14 @@ impl<'pool, FLBitmap: BinInteger, SLBitmap: BinInteger, const FLLEN: usize, cons
         block.as_mut().size = size;
 
         // Link this free block to the corresponding free list
-        let block = block.cast::<FreeBlockHdr>();
+        let mut block = block.cast::<FreeBlockHdr>();
         self.link_free_block(block, size);
 
         // Link `new_next_phys_block.prev_phys_block` to `block`
-        debug_assert_eq!(new_next_phys_block, block.as_ref().common.next_phys_block());
+        debug_assert_eq!(
+            new_next_phys_block,
+            BlockHdr::next_phys_block(addr_of_mut!(block.as_mut().common))
+        );
         new_next_phys_block.as_mut().prev_phys_block = Some(block.cast());
     }
 
@@ -1250,7 +1252,8 @@ impl<'pool, FLBitmap: BinInteger, SLBitmap: BinInteger, const FLLEN: usize, cons
                 let mut new_free_block_size = shrink_by;
 
                 // If the next block is a free block...
-                let mut next_phys_block = block.as_ref().common.next_phys_block();
+                let mut next_phys_block =
+                    BlockHdr::next_phys_block(addr_of_mut!(block.as_mut().common));
                 let next_phys_block_size_and_flags = next_phys_block.as_ref().size;
                 if (next_phys_block_size_and_flags & SIZE_USED) == 0 {
                     let next_phys_block_size = next_phys_block_size_and_flags;
@@ -1264,7 +1267,8 @@ impl<'pool, FLBitmap: BinInteger, SLBitmap: BinInteger, const FLLEN: usize, cons
                     self.unlink_free_block(next_phys_block.cast(), next_phys_block_size);
                     new_free_block_size += next_phys_block_size;
 
-                    let mut next_next_phys_block = next_phys_block.as_ref().next_phys_block();
+                    let mut next_next_phys_block =
+                        BlockHdr::next_phys_block(next_phys_block.as_ptr());
                     next_next_phys_block.as_mut().prev_phys_block = Some(new_free_block.cast());
                 } else {
                     // We can't merge a used block (`next_phys_block`) and
@@ -1290,7 +1294,7 @@ impl<'pool, FLBitmap: BinInteger, SLBitmap: BinInteger, const FLLEN: usize, cons
         debug_assert!(new_size > old_size);
 
         let grow_by = new_size - old_size;
-        let next_phys_block = block.as_ref().common.next_phys_block();
+        let next_phys_block = BlockHdr::next_phys_block(addr_of_mut!(block.as_mut().common));
 
         // If we removed this block, there would be a continous free space of
         // `moving_clearance` bytes, which is followed by `moving_clearance_end`
@@ -1315,7 +1319,8 @@ impl<'pool, FLBitmap: BinInteger, SLBitmap: BinInteger, const FLLEN: usize, cons
 
             // Now we know it's really a free block.
             let mut next_phys_block = next_phys_block.cast::<FreeBlockHdr>();
-            let mut next_next_phys_block = next_phys_block.as_ref().common.next_phys_block();
+            let mut next_next_phys_block =
+                BlockHdr::next_phys_block(addr_of_mut!(next_phys_block.as_mut().common));
 
             moving_clearance += next_phys_block_size;
             moving_clearance_end = next_next_phys_block;
@@ -1443,7 +1448,8 @@ impl<'pool, FLBitmap: BinInteger, SLBitmap: BinInteger, const FLLEN: usize, cons
                 self.unlink_free_block(moving_clearance_end.cast(), moving_clearance_end_size);
                 new_free_block_size += moving_clearance_end_size_and_flags;
 
-                let mut next_next_phys_block = moving_clearance_end.as_ref().next_phys_block();
+                let mut next_next_phys_block =
+                    BlockHdr::next_phys_block(moving_clearance_end.as_mut());
                 next_next_phys_block.as_mut().prev_phys_block = Some(new_free_block.cast());
             } else {
                 // We can't merge a used block (`moving_clearance_end`) and

--- a/crates/rlsf/src/tlsf/tests.rs
+++ b/crates/rlsf/src/tlsf/tests.rs
@@ -139,8 +139,8 @@ macro_rules! gen_test {
 
                 let mut tlsf: TheTlsf = Tlsf::new();
 
-                let mut pool = Align([MaybeUninit::uninit(); 512]);
-                let mut cursor = pool.0[0].as_mut_ptr() as *mut u8;
+                let mut pool = Align([MaybeUninit::<u8>::uninit(); 512]);
+                let mut cursor = pool.0.as_mut_ptr() as *mut u8;
                 let mut remaining_len = 512;
 
                 let pool0_len = unsafe {

--- a/crates/rlsf/src/utils.rs
+++ b/crates/rlsf/src/utils.rs
@@ -37,3 +37,10 @@ pub fn nonnull_slice_start<T>(ptr: NonNull<[T]>) -> NonNull<T> {
 pub unsafe fn nonnull_slice_end<T>(ptr: NonNull<[T]>) -> *mut T {
     (ptr.as_ptr() as *mut T).wrapping_add(nonnull_slice_len(ptr))
 }
+
+/// Get a pointer to a field in `NonNull<Struct>`.
+macro_rules! nn_field {
+    ($ptr:expr, $($tt:tt)*) => {
+        core::ptr::addr_of_mut!((*$ptr.as_ptr()).$($tt)*)
+    };
+}

--- a/crates/rlsf/src/utils.rs
+++ b/crates/rlsf/src/utils.rs
@@ -7,15 +7,19 @@ pub fn nonnull_slice_from_raw_parts<T>(ptr: NonNull<T>, len: usize) -> NonNull<[
 }
 
 /// Polyfill for  <https://github.com/rust-lang/rust/issues/71146>
+///
+/// # Safety
+///
+/// `ptr` must be dereferencable. This is a limitation of the polyfill.
 #[inline]
-pub fn nonnull_slice_len<T>(ptr: NonNull<[T]>) -> usize {
+pub unsafe fn nonnull_slice_len<T>(ptr: NonNull<[T]>) -> usize {
     // FIXME: Use `NonNull<[T]>::len` (stabilized in Rust 1.63)
     // Safety: We are just reading the slice length embedded in the fat
     //         pointer and not dereferencing the pointer. We also convert it
     //         to `*mut [MaybeUninit<UnsafeCell<u8>>]` just in case because the
     //         slice might be uninitialized and there might be outstanding
     //         mutable references to the slice.
-    unsafe { (&*(ptr.as_ptr() as *const [MaybeUninit<UnsafeCell<T>>])).len() }
+    (&*(ptr.as_ptr() as *const [MaybeUninit<UnsafeCell<T>>])).len()
 }
 
 // Polyfill for <https://github.com/rust-lang/rust/issues/74265>
@@ -24,7 +28,12 @@ pub fn nonnull_slice_start<T>(ptr: NonNull<[T]>) -> NonNull<T> {
     unsafe { NonNull::new_unchecked(ptr.as_ptr() as *mut T) }
 }
 
+/// Get the one-past-end pointer of a slice pointer.
+///
+/// # Safety
+///
+/// `ptr` must be dereferencable. This is a limitation of [`nonnull_slice_len`].
 #[inline]
-pub fn nonnull_slice_end<T>(ptr: NonNull<[T]>) -> *mut T {
+pub unsafe fn nonnull_slice_end<T>(ptr: NonNull<[T]>) -> *mut T {
     (ptr.as_ptr() as *mut T).wrapping_add(nonnull_slice_len(ptr))
 }

--- a/crates/rlsf/src/utils.rs
+++ b/crates/rlsf/src/utils.rs
@@ -1,4 +1,4 @@
-use core::{mem::MaybeUninit, ptr::NonNull};
+use core::{cell::UnsafeCell, mem::MaybeUninit, ptr::NonNull};
 
 /// Polyfill for <https://github.com/rust-lang/rust/issues/71941>
 #[inline]
@@ -9,11 +9,13 @@ pub fn nonnull_slice_from_raw_parts<T>(ptr: NonNull<T>, len: usize) -> NonNull<[
 /// Polyfill for  <https://github.com/rust-lang/rust/issues/71146>
 #[inline]
 pub fn nonnull_slice_len<T>(ptr: NonNull<[T]>) -> usize {
+    // FIXME: Use `NonNull<[T]>::len` (stabilized in Rust 1.63)
     // Safety: We are just reading the slice length embedded in the fat
     //         pointer and not dereferencing the pointer. We also convert it
-    //         to `*mut [MaybeUninit<u8>]` just in case because the slice
-    //         might be uninitialized.
-    unsafe { (*(ptr.as_ptr() as *const [MaybeUninit<T>])).len() }
+    //         to `*mut [MaybeUninit<UnsafeCell<u8>>]` just in case because the
+    //         slice might be uninitialized and there might be outstanding
+    //         mutable references to the slice.
+    unsafe { (&*(ptr.as_ptr() as *const [MaybeUninit<UnsafeCell<T>>])).len() }
 }
 
 // Polyfill for <https://github.com/rust-lang/rust/issues/74265>


### PR DESCRIPTION
Makes the code compliant with the current aliasing model. Fixes #9.

# Remaining Issues

- [x] Running MIRI in CI takes too long (4 hours in local run)
- [x] ~~Test failure in `cargo +nightly miri test -p rlsf --test global nonexistent`~~
    - Limitation in Stacked Borrow: https://github.com/rust-lang/miri/issues/2104
    - #18

# Limitations

- Not compliant with strict provenance yet (#12) and causes Miri to generate integer-to-pointer cast warnings (Strict Provenance API requires MSRV >= 1.84)
