### PR TITLE
Restore provenance in `GlobalAlloc::{de,re}alloc` when running on Miri

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,4 +92,6 @@ jobs:
 
       - name: cargo miri test (partial)
         # Miri is too slow to run all tests
-        run: cargo miri test -p rlsf --lib -- _u8_u8_8_8 global
+        run: |
+          cargo miri test -p rlsf --lib -- _u8_u8_8_8 global
+          cargo miri test -p rlsf --test global strings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed illegal pointer operations. `{Flex,}Tlsf` no longer trigger errors when running in MIRI.
+- Implemented a work-around for `GlobalAlloc::{dealloc,realloc}` receiving allocation pointers with insufficient provenance on Miri.
 
 ## [0.2.1] - 2023-02-17
 

--- a/crates/rlsf/src/global/unix.rs
+++ b/crates/rlsf/src/global/unix.rs
@@ -10,7 +10,9 @@ const MIN_ALIGN: usize = crate::GRANULARITY;
 
 /// The allocation unit, which is intentionally set to be larger than the usual
 /// page sizes to reduce overhead. TODO: Make this adjustable
-const ALLOC_UNIT: usize = 1 << 16;
+///
+/// A smaller value is used on Miri because it somehow speeds up execution.
+const ALLOC_UNIT: usize = if cfg!(miri) { 1 << 14 } else { 1 << 16 };
 
 pub struct Mutex(());
 


### PR DESCRIPTION
Work-around for https://github.com/rust-lang/miri/issues/2104

- [x] Make it compile on MSRV
- [ ] Commit message
- [x] Clearly document why `FORCE_POOL_FTR` is set
- [x] Use `iter_pools()` in `drop` too?